### PR TITLE
Feature/renaming feature maps

### DIFF
--- a/dc_qiskit_qml/distance_based/hadamard/_QmlHadamardNeighborClassifier.py
+++ b/dc_qiskit_qml/distance_based/hadamard/_QmlHadamardNeighborClassifier.py
@@ -61,7 +61,7 @@ from sklearn.neighbors.base import SupervisedIntegerMixin
 
 from dc_qiskit_qml.QiskitOptions import QiskitOptions
 from .state import QmlStateCircuitBuilder
-from ...feature_maps import FeatureMap
+from ...encoding_maps import EncodingMap
 
 log = logging.getLogger(__name__)
 
@@ -71,13 +71,13 @@ class QmlHadamardNeighborClassifier(BaseEstimator, SupervisedIntegerMixin, Class
     The Hadamard distance & majority based classifier implementing sci-kit learn's mechanism of fit/predict
     """
 
-    def __init__(self, feature_map, classifier_circuit_factory, backend, shots=1024, coupling_map=None,
+    def __init__(self, encoding_map, classifier_circuit_factory, backend, shots=1024, coupling_map=None,
                  basis_gates=None, theta=None, options=None):
-        # type: (FeatureMap, QmlStateCircuitBuilder, BaseBackend, int, CouplingMap, List[str], Optional[float], Optional[QiskitOptions]) -> None
+        # type: (EncodingMap, QmlStateCircuitBuilder, BaseBackend, int, CouplingMap, List[str], Optional[float], Optional[QiskitOptions]) -> None
         """
         Create the classifier
 
-        :param feature_map: a classical feature map to apply to every training and testing sample before building
+        :param encoding_map: a classical feature map to apply to every training and testing sample before building
         the circuit
         :param classifier_circuit_factory: the circuit building factory class
         :param backend: the qiskit backend to do the compilation & computation on
@@ -87,7 +87,7 @@ class QmlHadamardNeighborClassifier(BaseEstimator, SupervisedIntegerMixin, Class
         :param theta: an advanced feature that generalizes the "Hadamard" gate as a rotation with this angle
         :param options: the options for transpilation & executions with qiskit.
         """
-        self.feature_map = feature_map  # type: FeatureMap
+        self.encoding_map = encoding_map  # type: EncodingMap
         self.basis_gates = basis_gates  # type: List[str]
         self.shots = shots  # type: int
         self.backend = backend  # type: BaseBackend
@@ -142,8 +142,8 @@ class QmlHadamardNeighborClassifier(BaseEstimator, SupervisedIntegerMixin, Class
             log.info("Creating state for input %d: %s.", index, x)
             circuit_name = 'qml_hadamard_index_%d' % index
 
-            X_input = self.feature_map.map(x)
-            X_train = [self.feature_map.map(s) for s in self._X]
+            X_input = self.encoding_map.map(x)
+            X_train = [self.encoding_map.map(s) for s in self._X]
             qc = self.classifier_state_factory.build_circuit(circuit_name=circuit_name, X_train=X_train,
                                                              y_train=self._y, X_input=X_input)  # type: QuantumCircuit
             ancilla = [q for q in qc.qregs if q.name == 'a'][0]

--- a/dc_qiskit_qml/encoding_maps/_EncodingMap.py
+++ b/dc_qiskit_qml/encoding_maps/_EncodingMap.py
@@ -14,8 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ._FeatureMap import FeatureMap
-from ._FixedLengthQubitEncoding import FixedLengthQubitEncoding
-from ._Float32QubitEncoding import Float32QubitEncoding
-from ._IdentityFeatureMap import IdentityFeatureMap
-from ._NormedAmplitudeEncoding import NormedAmplitudeEncoding
+from typing import List
+
+from scipy import sparse
+
+
+class EncodingMap(object):
+    def map(self, input_vector):
+        # type: (EncodingMap, List[complex]) -> sparse.dok_matrix
+        pass

--- a/dc_qiskit_qml/encoding_maps/_FixedLengthQubitEncoding.py
+++ b/dc_qiskit_qml/encoding_maps/_FixedLengthQubitEncoding.py
@@ -19,10 +19,10 @@ from typing import List
 import numpy as np
 from scipy import sparse
 
-from . import FeatureMap
+from . import EncodingMap
 
 
-class FixedLengthQubitEncoding(FeatureMap):
+class FixedLengthQubitEncoding(EncodingMap):
     def __init__(self, integer_length, decimal_length):
         self.integer_length = integer_length
         self.decimal_length = decimal_length

--- a/dc_qiskit_qml/encoding_maps/_Float32QubitEncoding.py
+++ b/dc_qiskit_qml/encoding_maps/_Float32QubitEncoding.py
@@ -14,25 +14,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List
 
-import logging
-
+import bitstring
 import numpy as np
 from scipy import sparse
 
-from . import FeatureMap
-
-log = logging.getLogger('VectorAmplitudeEncoding')
+from . import EncodingMap
 
 
-class NormedAmplitudeEncoding(FeatureMap):
+class Float32QubitEncoding(EncodingMap):
     def map(self, x):
-        # type: (NormedAmplitudeEncoding, any) -> sparse.dok_matrix
+        # type: (Float32QubitEncoding, List[complex]) -> sparse.dok_matrix
         x_array = np.asarray(x)
-        x_norm = np.linalg.norm(x_array)
-        x_array = x_array / x_norm
-        log.info("Normed Input Vector: %s" % x_array)
-        feature_x = sparse.dok_matrix((x_array.size, 1), dtype=complex)  # type: sparse.dok_matrix
-        for i, e in enumerate(x_array):
-            feature_x[i, 0] = e/x_norm
+        x_norm = np.sqrt(x_array.size)
+        feature_length = x_array.shape[0] * 32
+        feature_x = sparse.dok_matrix((2**feature_length, 1), dtype=complex)  # type: sparse.dok_matrix
+        e = None  # type: np.float64
+        for e in x_array:
+            sbit = bitstring.pack('float:32', e)
+            qubit_state = sbit.bin
+            index_for = int(qubit_state, 2)
+            feature_x[index_for, 0] = 1.0/x_norm
         return feature_x

--- a/dc_qiskit_qml/encoding_maps/_IdentityEncodingMap.py
+++ b/dc_qiskit_qml/encoding_maps/_IdentityEncodingMap.py
@@ -19,12 +19,12 @@ from typing import List
 
 from scipy import sparse
 
-from . import FeatureMap
+from . import EncodingMap
 
 
-class IdentityFeatureMap(FeatureMap):
+class IdentityEncodingMap(EncodingMap):
     def map(self, input_vector):
-        # type: (IdentityFeatureMap, List[complex]) -> sparse.dok_matrix
+        # type: (IdentityEncodingMap, List[complex]) -> sparse.dok_matrix
         result = sparse.dok_matrix((len(input_vector), 1))
         for i, v in enumerate(input_vector):
             result[i, 0] = v

--- a/dc_qiskit_qml/encoding_maps/__init__.py
+++ b/dc_qiskit_qml/encoding_maps/__init__.py
@@ -14,12 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
-
-from scipy import sparse
-
-
-class FeatureMap(object):
-    def map(self, input_vector):
-        # type: (FeatureMap, List[complex]) -> sparse.dok_matrix
-        pass
+from ._EncodingMap import EncodingMap
+from ._FixedLengthQubitEncoding import FixedLengthQubitEncoding
+from ._Float32QubitEncoding import Float32QubitEncoding
+from ._IdentityEncodingMap import IdentityEncodingMap
+from ._NormedAmplitudeEncoding import NormedAmplitudeEncoding

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ info = {
         'dc_qiskit_qml.distance_based.hadamard.state',
         'dc_qiskit_qml.distance_based.hadamard.state.cnot',
         'dc_qiskit_qml.distance_based.hadamard.state.sparsevector',
-        'dc_qiskit_qml.feature_maps'
+        'dc_qiskit_qml.encoding_maps'
     ],
     'description': 'Machine learning (quantum-)algorithms with qiskit as basis',
     'long_description': open('README.rst').read(),

--- a/tests/test_QmlBinaryDataStateCircuitBuilder.py
+++ b/tests/test_QmlBinaryDataStateCircuitBuilder.py
@@ -21,8 +21,8 @@ from scipy import sparse
 
 from dc_qiskit_qml.distance_based.hadamard.state import QmlBinaryDataStateCircuitBuilder
 from dc_qiskit_qml.distance_based.hadamard.state.cnot import CCXMöttönen, CCXToffoli
-from dc_qiskit_qml.feature_maps import FeatureMap
-from dc_qiskit_qml.feature_maps import FixedLengthQubitEncoding
+from dc_qiskit_qml.encoding_maps import EncodingMap
+from dc_qiskit_qml.encoding_maps import FixedLengthQubitEncoding
 
 logger = logging.getLogger()
 logger.level = logging.DEBUG
@@ -39,7 +39,7 @@ def extract_gate_info(qc, index):
 class QubitEncodingClassifierStateCircuitTests(unittest.TestCase):
 
     def test_one(self):
-        feature_map = FixedLengthQubitEncoding(4, 4)
+        encoding_map = FixedLengthQubitEncoding(4, 4)
 
         X_train = [
             [4.4, -9.53],
@@ -48,20 +48,20 @@ class QubitEncodingClassifierStateCircuitTests(unittest.TestCase):
         y_train = [0, 1]
         input = [2.043, 13.84]
 
-        X_train_in_feature_space = [feature_map.map(x) for x in X_train]
-        X_train_in_feature_space_qubit_notation = [["{:b}".format(i).zfill(2 * 9) for i, _ in elem.keys()] for elem in
-                                                   X_train_in_feature_space]
+        X_train_in_encoded_space = [encoding_map.map(x) for x in X_train]
+        X_train_in_encoded_space_qubit_notation = [["{:b}".format(i).zfill(2 * 9) for i, _ in elem.keys()] for elem in
+                                                   X_train_in_encoded_space]
 
-        input_in_feature_space = feature_map.map(input)
+        input_in_feature_space = encoding_map.map(input)
         input_in_feature_space_qubit_notation = ["{:b}".format(i).zfill(2 * 9) for i, _ in
                                                  input_in_feature_space.keys()]
 
-        logger.info("Training samples in feature space: {}".format(X_train_in_feature_space_qubit_notation))
-        logger.info("Input sample in feature space: {}".format(input_in_feature_space_qubit_notation))
+        logger.info("Training samples in encoded space: {}".format(X_train_in_encoded_space_qubit_notation))
+        logger.info("Input sample in encoded space: {}".format(input_in_feature_space_qubit_notation))
 
         circuit = QmlBinaryDataStateCircuitBuilder(CCXMöttönen())
 
-        qc = circuit.build_circuit('test', X_train=X_train_in_feature_space, y_train=y_train, X_input=input_in_feature_space)
+        qc = circuit.build_circuit('test', X_train=X_train_in_encoded_space, y_train=y_train, X_input=input_in_feature_space)
 
         self.assertIsNotNone(qc)
         self.assertIsNotNone(qc.data)
@@ -101,7 +101,7 @@ class QubitEncodingClassifierStateCircuitTests(unittest.TestCase):
 
     def test_two(self):
 
-        feature_map = FixedLengthQubitEncoding(2, 2)
+        encoding_map = FixedLengthQubitEncoding(2, 2)
 
         X_train = [
             [4.4, -9.53],
@@ -110,18 +110,18 @@ class QubitEncodingClassifierStateCircuitTests(unittest.TestCase):
         y_train = [0, 1]
         input = [2.043, 13.84]
 
-        X_train_in_feature_space = [feature_map.map(x) for x in X_train]
-        X_train_in_feature_space_qubit_notation = [["{:b}".format(i).zfill(2*5) for i, _ in elem.keys()] for elem in X_train_in_feature_space]
+        X_train_in_encoded_space = [encoding_map.map(x) for x in X_train]
+        X_train_in_encoded_space_qubit_notation = [["{:b}".format(i).zfill(2*5) for i, _ in elem.keys()] for elem in X_train_in_encoded_space]
 
-        input_in_feature_space = feature_map.map(input)
+        input_in_feature_space = encoding_map.map(input)
         input_in_feature_space_qubit_notation = ["{:b}".format(i).zfill(2*5) for i, _ in input_in_feature_space.keys()]
 
-        logger.info("Training samples in feature space: {}".format(X_train_in_feature_space_qubit_notation))
-        logger.info("Input sample in feature space: {}".format(input_in_feature_space_qubit_notation))
+        logger.info("Training samples in encoded space: {}".format(X_train_in_encoded_space_qubit_notation))
+        logger.info("Input sample in encoded space: {}".format(input_in_feature_space_qubit_notation))
 
         circuit = QmlBinaryDataStateCircuitBuilder(CCXMöttönen())
 
-        qc = circuit.build_circuit('test', X_train=X_train_in_feature_space, y_train=y_train, X_input=input_in_feature_space)
+        qc = circuit.build_circuit('test', X_train=X_train_in_encoded_space, y_train=y_train, X_input=input_in_feature_space)
 
         self.assertIsNotNone(qc)
         self.assertIsNotNone(qc.data)
@@ -166,7 +166,7 @@ class QubitEncodingClassifierStateCircuitTests(unittest.TestCase):
         self.assertListEqual(sorted(counts.keys()), sorted(['0 0100111010 0 0', '0 0100001111 0 1', '1 0100100100 1 0', '1 0100001111 1 1']))
 
     def test_three(self):
-        feature_map = FixedLengthQubitEncoding(4, 4)
+        encoding_map = FixedLengthQubitEncoding(4, 4)
 
         X_train = [
             [4.4, -9.53],
@@ -175,20 +175,20 @@ class QubitEncodingClassifierStateCircuitTests(unittest.TestCase):
         y_train = [0, 1]
         input = [2.043, 13.84]
 
-        X_train_in_feature_space = [feature_map.map(x) for x in X_train]
-        X_train_in_feature_space_qubit_notation = [["{:b}".format(i).zfill(2 * 9) for i, _ in elem.keys()] for elem in
-                                                   X_train_in_feature_space]
+        X_train_in_encoded_space = [encoding_map.map(x) for x in X_train]
+        X_train_in_encoded_space_qubit_notation = [["{:b}".format(i).zfill(2 * 9) for i, _ in elem.keys()] for elem in
+                                                   X_train_in_encoded_space]
 
-        input_in_feature_space = feature_map.map(input)
+        input_in_feature_space = encoding_map.map(input)
         input_in_feature_space_qubit_notation = ["{:b}".format(i).zfill(2 * 9) for i, _ in
                                                  input_in_feature_space.keys()]
 
-        logger.info("Training samples in feature space: {}".format(X_train_in_feature_space_qubit_notation))
-        logger.info("Input sample in feature space: {}".format(input_in_feature_space_qubit_notation))
+        logger.info("Training samples in encoded space: {}".format(X_train_in_encoded_space_qubit_notation))
+        logger.info("Input sample in encoded space: {}".format(input_in_feature_space_qubit_notation))
 
         circuit = QmlBinaryDataStateCircuitBuilder(CCXToffoli())
 
-        qc = circuit.build_circuit('test', X_train=X_train_in_feature_space, y_train=y_train, X_input=input_in_feature_space)
+        qc = circuit.build_circuit('test', X_train=X_train_in_encoded_space, y_train=y_train, X_input=input_in_feature_space)
 
         self.assertIsNotNone(qc)
         self.assertIsNotNone(qc.data)
@@ -243,7 +243,7 @@ class QubitEncodingClassifierStateCircuitTests(unittest.TestCase):
 
     def test_four(self):
 
-        feature_map = FixedLengthQubitEncoding(2, 2)
+        encoding_map = FixedLengthQubitEncoding(2, 2)
 
         X_train = [
             [4.4, -9.53],
@@ -252,17 +252,17 @@ class QubitEncodingClassifierStateCircuitTests(unittest.TestCase):
         y_train = [0, 1]
         input = [2.043, 13.84]
 
-        X_train_in_feature_space = [feature_map.map(x) for x in X_train]
-        X_train_in_feature_space_qubit_notation = [["{:b}".format(i).zfill(2*5) for i, _ in elem.keys()] for elem in X_train_in_feature_space]
+        X_train_in_encoded_space = [encoding_map.map(x) for x in X_train]
+        X_train_in_encoded_space_qubit_notation = [["{:b}".format(i).zfill(2*5) for i, _ in elem.keys()] for elem in X_train_in_encoded_space]
 
-        input_in_feature_space = feature_map.map(input)
-        input_in_feature_space_qubit_notation = ["{:b}".format(i).zfill(2*5) for i, _ in input_in_feature_space.keys()]
+        input_in_encoded_space = encoding_map.map(input)
+        input_in_encoded_space_qubit_notation = ["{:b}".format(i).zfill(2*5) for i, _ in input_in_encoded_space.keys()]
 
-        logger.info("Training samples in feature space: {}".format(X_train_in_feature_space_qubit_notation))
-        logger.info("Input sample in feature space: {}".format(input_in_feature_space_qubit_notation))
+        logger.info("Training samples in encoded space: {}".format(X_train_in_encoded_space_qubit_notation))
+        logger.info("Input sample in encoded space: {}".format(input_in_encoded_space_qubit_notation))
 
         circuit = QmlBinaryDataStateCircuitBuilder(CCXToffoli())
-        qc = circuit.build_circuit('test', X_train=X_train_in_feature_space, y_train=y_train, X_input=input_in_feature_space)
+        qc = circuit.build_circuit('test', X_train=X_train_in_encoded_space, y_train=y_train, X_input=input_in_encoded_space)
 
         self.assertIsNotNone(qc)
         self.assertIsNotNone(qc.data)
@@ -328,7 +328,7 @@ class QubitEncodingClassifierStateCircuitTests(unittest.TestCase):
         X_test = np.asarray([[0.2, 0.4], [0.4, -0.8]])
         y_test = [0, 1]
 
-        class MyFeatureMap(FeatureMap):
+        class MyEncodingMap(EncodingMap):
             def map(self, input_vector: list) -> sparse.dok_matrix:
                 result = sparse.dok_matrix((4, 1))
                 index = 0
@@ -345,10 +345,10 @@ class QubitEncodingClassifierStateCircuitTests(unittest.TestCase):
 
         initial_state_builder = QmlBinaryDataStateCircuitBuilder(CCXToffoli())
 
-        feature_map = MyFeatureMap()
-        X_train_in_feature_space = [feature_map.map(s) for s in X_train]
-        X_test_in_feature_space = [feature_map.map(s) for s in X_test]
-        qc = initial_state_builder.build_circuit('test', X_train_in_feature_space, y_train, X_test_in_feature_space[0])
+        encoding_map = MyEncodingMap()
+        X_train_in_encoded_space = [encoding_map.map(s) for s in X_train]
+        X_test_in_encoded_space = [encoding_map.map(s) for s in X_test]
+        qc = initial_state_builder.build_circuit('test', X_train_in_encoded_space, y_train, X_test_in_encoded_space[0])
 
         self.assertIsNotNone(qc)
         self.assertIsNotNone(qc.data)

--- a/tests/test_QmlGenericStateCircuitBuilder.py
+++ b/tests/test_QmlGenericStateCircuitBuilder.py
@@ -10,7 +10,7 @@ from sklearn.preprocessing import StandardScaler, Normalizer
 
 from dc_qiskit_qml.distance_based.hadamard.state import QmlGenericStateCircuitBuilder
 from dc_qiskit_qml.distance_based.hadamard.state.sparsevector import MöttönenStatePreparation
-from dc_qiskit_qml.feature_maps import IdentityFeatureMap
+from dc_qiskit_qml.encoding_maps import IdentityEncodingMap
 
 logging.basicConfig(format=logging.BASIC_FORMAT, level='INFO')
 log = logging.getLogger(__name__)
@@ -32,11 +32,11 @@ class MöttönenStatePreparationTest(unittest.TestCase):
         X = preprocessing_pipeline.fit_transform(X, y)
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.10, random_state=42)
 
-        feature_map = IdentityFeatureMap()
+        encoding_map = IdentityEncodingMap()
         initial_state_builder = QmlGenericStateCircuitBuilder(MöttönenStatePreparation())
 
-        qc = initial_state_builder.build_circuit("test", [feature_map.map(e) for e in X_train], y_train,
-                                            feature_map.map(X_test[0]))
+        qc = initial_state_builder.build_circuit("test", [encoding_map.map(e) for e in X_train], y_train,
+                                                 encoding_map.map(X_test[0]))
         statevector_backend = qiskit.Aer.get_backend('statevector_simulator')  # type: BaseBackend
         job = qiskit.execute(qc, statevector_backend, shots=1)  # type: BaseJob
         simulator_state_vector = job.result().get_statevector()

--- a/tests/test_QmlHadamardNeighborClassifier.py
+++ b/tests/test_QmlHadamardNeighborClassifier.py
@@ -24,7 +24,7 @@ from dc_qiskit_qml.distance_based.hadamard.state.cnot import CCXToffoli
 from dc_qiskit_qml.distance_based.hadamard.state.sparsevector import MöttönenStatePreparation
 from dc_qiskit_qml.distance_based.hadamard.state.sparsevector import FFQRAMStateVectorRoutine
 from dc_qiskit_qml.distance_based.hadamard.state.sparsevector import QiskitNativeStatePreparation
-from dc_qiskit_qml.feature_maps import FeatureMap, NormedAmplitudeEncoding
+from dc_qiskit_qml.encoding_maps import EncodingMap, NormedAmplitudeEncoding
 
 logging.basicConfig(format=logging.BASIC_FORMAT, level='INFO')
 log = logging.getLogger(__name__)
@@ -80,7 +80,7 @@ class QmlHadamardMöttönenTests(unittest.TestCase):
 
         classifier_state_factory = QmlGenericStateCircuitBuilder(MöttönenStatePreparation())
 
-        qml = QmlHadamardNeighborClassifier(feature_map=NormedAmplitudeEncoding(),
+        qml = QmlHadamardNeighborClassifier(encoding_map=NormedAmplitudeEncoding(),
                                             classifier_circuit_factory=classifier_state_factory,
                                             backend=execution_backend, shots=100 * 8192)
         y_predict, y_test = predict(qml)
@@ -107,7 +107,7 @@ class QmlHadamardFFQramTests(unittest.TestCase):
 
         qml = QmlHadamardNeighborClassifier(backend=execution_backend,
                                             classifier_circuit_factory=classifier_state_factory,
-                                            feature_map=NormedAmplitudeEncoding(),
+                                            encoding_map=NormedAmplitudeEncoding(),
                                             shots=100 * 8192)
 
         y_predict, y_test = predict(qml)
@@ -134,7 +134,7 @@ class QmlHadamardQiskitInitializerTests(unittest.TestCase):
 
         qml = QmlHadamardNeighborClassifier(backend=execution_backend,
                                             classifier_circuit_factory=classifier_state_factory,
-                                            feature_map=NormedAmplitudeEncoding(),
+                                            encoding_map=NormedAmplitudeEncoding(),
                                             shots=100 * 8192)
 
         y_predict, y_test = predict(qml)
@@ -160,7 +160,7 @@ class QmlHadamardMultiClassesTests(unittest.TestCase):
 
         classifier_state_factory = QmlGenericStateCircuitBuilder(MöttönenStatePreparation())
 
-        qml = QmlHadamardNeighborClassifier(feature_map=NormedAmplitudeEncoding(),
+        qml = QmlHadamardNeighborClassifier(encoding_map=NormedAmplitudeEncoding(),
                                             classifier_circuit_factory=classifier_state_factory,
                                             backend=execution_backend, shots=100 * 8192)
 
@@ -204,7 +204,7 @@ class QmlHadamardCNOTQubitEncodingTests(unittest.TestCase):
         X_test = numpy.asarray([[0.2, 0.4], [0.4, -0.8]])
         y_test = [0, 1]
 
-        class MyFeatureMap(FeatureMap):
+        class MyEncodingMap(EncodingMap):
             def map(self, input_vector: list) -> sparse.dok_matrix:
                 result = sparse.dok_matrix((4, 1))
                 index = 0
@@ -219,13 +219,13 @@ class QmlHadamardCNOTQubitEncodingTests(unittest.TestCase):
                 result[index, 0] = 1.0
                 return result
 
-        feature_map = MyFeatureMap()
+        encoding_map = MyEncodingMap()
 
         initial_state_builder = QmlBinaryDataStateCircuitBuilder(CCXToffoli())
 
         qml = QmlHadamardNeighborClassifier(backend=execution_backend,
                                             shots=100 * 8192,
-                                            feature_map=feature_map,
+                                            encoding_map=encoding_map,
                                             classifier_circuit_factory=initial_state_builder)
 
         qml.fit(X_train, y_train)
@@ -258,7 +258,7 @@ class FullIris(unittest.TestCase):
         qml = QmlHadamardNeighborClassifier(backend=execution_backend,
                                             shots=8192,
                                             classifier_circuit_factory=initial_state_builder,
-                                            feature_map=NormedAmplitudeEncoding())
+                                            encoding_map=NormedAmplitudeEncoding())
 
         qml.fit(X_train, y_train)
         prediction = qml.predict(X_test)


### PR DESCRIPTION
While this part in some sense qualifies also as feature map, it is more related in getting classical data into the a vector format (in Hilbert space) as classical preprocessing step. A feature map though is better used in conjunction with a quantum operation that maps some parameters natively into Hilbert space. The renaming makes this difference apparent.