### PR TITLE
Feature/refactorings and updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
 cache: pip
 python:
-  - 3.5
   - 3.6
+  - 3.7
+  - 3.8
+  - 3.9
 env:
   - LOGGING=info
 before_install:

--- a/dc_qiskit_qml/distance_based/hadamard/_QmlHadamardNeighborClassifier.py
+++ b/dc_qiskit_qml/distance_based/hadamard/_QmlHadamardNeighborClassifier.py
@@ -56,8 +56,7 @@ from qiskit.qobj import Qobj
 from qiskit.result import Result
 from qiskit.result.models import ExperimentResult
 from qiskit.transpiler import CouplingMap
-from sklearn.base import ClassifierMixin, TransformerMixin, BaseEstimator
-from sklearn.neighbors.base import SupervisedIntegerMixin
+from sklearn.base import ClassifierMixin, TransformerMixin
 
 from dc_qiskit_qml.QiskitOptions import QiskitOptions
 from .state import QmlStateCircuitBuilder
@@ -66,7 +65,7 @@ from ...encoding_maps import EncodingMap
 log = logging.getLogger(__name__)
 
 
-class QmlHadamardNeighborClassifier(BaseEstimator, SupervisedIntegerMixin, ClassifierMixin, TransformerMixin):
+class QmlHadamardNeighborClassifier(ClassifierMixin, TransformerMixin):
     """
     The Hadamard distance & majority based classifier implementing sci-kit learn's mechanism of fit/predict
     """

--- a/dc_qiskit_qml/distance_based/hadamard/_QmlHadamardNeighborClassifier.py
+++ b/dc_qiskit_qml/distance_based/hadamard/_QmlHadamardNeighborClassifier.py
@@ -93,6 +93,7 @@ class QmlHadamardNeighborClassifier(BaseEstimator, SupervisedIntegerMixin, Class
         self.backend = backend  # type: BaseBackend
         self.coupling_map = coupling_map  # type: CouplingMap
         self._X = np.asarray([])  # type: np.ndarray
+        self._y = np.asarray([])  # type: np.ndarray
         self.last_predict_X = None
         self.last_predict_label = None
         self.last_predict_probability = []  # type: List[float]
@@ -113,7 +114,7 @@ class QmlHadamardNeighborClassifier(BaseEstimator, SupervisedIntegerMixin, Class
     def transform(self, X, y='deprecated', copy=None):
         return X
 
-    def _fit(self, X):
+    def fit(self, X, y):
         # type: (QmlHadamardNeighborClassifier, Iterable) -> QmlHadamardNeighborClassifier
         """
         Internal fit method just saves the train sample set
@@ -121,6 +122,7 @@ class QmlHadamardNeighborClassifier(BaseEstimator, SupervisedIntegerMixin, Class
         :param X: array_like, training sample
         """
         self._X = np.asarray(X)
+        self._y = y
         log.debug("Setting training data:")
         for x, y in zip(self._X, self._y):
             log.debug("%s: %s", x, y)

--- a/dc_qiskit_qml/distance_based/hadamard/_QmlHadamardNeighborClassifier.py
+++ b/dc_qiskit_qml/distance_based/hadamard/_QmlHadamardNeighborClassifier.py
@@ -148,7 +148,7 @@ class QmlHadamardNeighborClassifier(ClassifierMixin, TransformerMixin):
             X_train = [self.encoding_map.map(s) for s in self._X]
             qc = self.classifier_state_factory.build_circuit(circuit_name=circuit_name, X_train=X_train,
                                                              y_train=self._y, X_input=X_input)  # type: QuantumCircuit
-            ancilla = [q for q in qc.qregs if q.name == 'a'][0]
+            ancillary = [q for q in qc.qregs if q.name == 'a'][0]
             qlabel = [q for q in qc.qregs if q.name == 'l^q'][0]
             clabel = [q for q in qc.cregs if q.name == 'l^c'][0]
             branch = [q for q in qc.cregs if q.name == 'b'][0]
@@ -156,18 +156,18 @@ class QmlHadamardNeighborClassifier(ClassifierMixin, TransformerMixin):
             # Classifier
             # Instead of a Hadamard gate we want this to be parametrized
             # use comments for now to toggle!
-            # standard.h(qc, ancilla)
+            # standard.h(qc, ancillary)
             # Must be minus, as the IBMQX gate is implemented this way!
-            qc.ry(-self.theta, ancilla)
-            qc.z(ancilla)
+            qc.ry(-self.theta, ancillary)
+            qc.z(ancillary)
 
             # Make sure measurements aren't shifted around
             # This would have some consequences as no gates
             # are allowed after a measurement.
             qc.barrier()
 
-            # The correct label is on ancilla branch |0>!
-            measure(qc, ancilla[0], branch[0])
+            # The correct label is on ancillary branch |0>!
+            measure(qc, ancillary[0], branch[0])
             measure(qc, qlabel, clabel)
 
             self._last_predict_circuits.append(qc)

--- a/dc_qiskit_qml/distance_based/hadamard/state/_QmlBinaryDataStateCircuitBuilder.py
+++ b/dc_qiskit_qml/distance_based/hadamard/state/_QmlBinaryDataStateCircuitBuilder.py
@@ -40,7 +40,6 @@ from typing import List
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.dagcircuit import DAGNode
-from qiskit.extensions.standard.h import h
 from scipy import sparse
 
 from . import QmlStateCircuitBuilder
@@ -121,8 +120,8 @@ class QmlBinaryDataStateCircuitBuilder(QmlStateCircuitBuilder):
         # ======================
 
         # Superposition on ancilla & index
-        h(qc, ancilla)
-        h(qc, index)
+        qc.h(ancilla)
+        qc.h(index)
 
         # Create multi-CNOTs
         # First on the sample, then the input and finally the label

--- a/dc_qiskit_qml/distance_based/hadamard/state/_measurement_outcome.py
+++ b/dc_qiskit_qml/distance_based/hadamard/state/_measurement_outcome.py
@@ -1,0 +1,10 @@
+class MeasurementOutcome:
+
+    label: int
+    branch: int
+    count: int
+
+    def __init__(self, label, branch, count) -> None:
+        self.count = count
+        self.label = label
+        self.branch = branch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-bitstring==3.1.7
-dc_qiskit_algorithms==0.0.12
-numpy==1.19.5
-qiskit==0.23.2
-scikit_learn==0.23.0
-scipy==1.6.0
+bitstring
+dc_qiskit_algorithms
+numpy
+qiskit
+scikit_learn
+scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-qiskit
-numpy
-scipy
-bitstring
-scikit_learn
-dc_qiskit_algorithms
+bitstring==3.1.7
+dc_qiskit_algorithms==0.0.12
+numpy==1.19.5
+qiskit==0.23.2
+scikit_learn==0.23.0
+scipy==1.6.0

--- a/tests/test_QmlGenericStateCircuitBuilder.py
+++ b/tests/test_QmlGenericStateCircuitBuilder.py
@@ -42,6 +42,9 @@ class MöttönenStatePreparationTest(unittest.TestCase):
         simulator_state_vector = job.result().get_statevector()
         input_state_vector = initial_state_builder.get_last_state_vector()
 
+        phase = set(numpy.angle(simulator_state_vector)[numpy.abs(simulator_state_vector) > 1e-3]).pop()
+        simulator_state_vector[numpy.abs(simulator_state_vector) < 1e-3] = 0
+        simulator_state_vector = numpy.exp(-1.0j * phase) * simulator_state_vector
         for i, s in zip(input_state_vector.toarray(), simulator_state_vector):
             log.debug("{:.4f} == {:.4f}".format(i[0], s))
-            self.assertAlmostEqual(i[0], s, places=4)
+            self.assertAlmostEqual(i[0], s, places=3)


### PR DESCRIPTION
Fixed the following:

- To take all current python version into account, test it on > 3.5. Remove 3.5.
- Fix: setting the Register Size in qiskit does not work anymore.... needed to fix the TODO now. Was way too complicated, I needed to recreate a new Quantum Circuit. But now this is also clean programming: no side effects.
- Fixing versions in the `requirements.txt` seems to be a good idea at first, but then different versions of python won't work. For now, I remove them again. 
- Somehow "ancillary" doesn't sound so harsh compared to "ancilla"... we should stop using it altogether. 
- A lot of refactoring, adding classes and abstractions. 
- The new mixins to be used for scikit-learn.
- scikit-learn update: Adding the label to the fit method, as is now customary 
- A global phase is destroying the test. This rather cumbersome way tries to remedy it... 
- I removed the old imports and the calls as they are now incorporated into the QuantumCircuit
